### PR TITLE
fix(login.minion): correct status class

### DIFF
--- a/lab/login/style.css
+++ b/lab/login/style.css
@@ -197,7 +197,7 @@
   display: inline-block;
 }
 
-.post-minion #status-minion {
+.post-minion .status-minion {
   order: 3;
   flex-basis: 100%; /* this ensures the post content will end up on a different line in the flex */
 }


### PR DESCRIPTION
The .status-minion class also used to have the #status-minion ID, allowing us to style based on that. As this is no longer the case, the badge ordering (and presumably fake <br/>) broke. Using .status-minion instead fixes the issue