### PR TITLE
Fix the PodeTond 💚 style

### DIFF
--- a/lab/login/user-style.css
+++ b/lab/login/user-style.css
@@ -186,13 +186,7 @@
 /* PodeTond 💚 */
 /* =========== */
 .name-PodeTond.💚\@todepond\.com {
-  background: linear-gradient(
-    to right,
-    #eaacb8 20%,
-    #7acbf5 80%,
-    var(--green) 80%,
-    var(--green) 100%
-  );
+  background: linear-gradient( to right, #eaacb8, #7acbf5 9ch, var(--green) 9ch );
   -webkit-text-fill-color: transparent;
   background-clip: text;
   display: inline-block; /* so it doesnt cut the heart */


### PR DESCRIPTION
It would be great if the domain wasn't also green, but there's a weird firefox bug with emojis and `ch` values (emojis get rendered in a different font so maybe that's why it breaks). Stopping before the emoji avoids the edge case.

Replies also work because of the space before the heart