### PR TITLE
Timeout the /login endpoint after 5 seconds

### DIFF
--- a/lab/login/index.html
+++ b/lab/login/index.html
@@ -109,12 +109,14 @@
     submitButton.textContent = "Logging in...";
 
     loadingFeed.style.display = "block";
-    const response = await fetch(config.endpoints.login, {
-      method: "POST",
-      body: JSON.stringify({ username, password }),
-    });
+    const json = await fetch(config.endpoints.login, {
+            signal: AbortSignal.timeout(5000),
+            method: 'POST',
+            body: JSON.stringify({ username, password }),
+        })
+            .then((res) => res.json())
+            .catch(() => ({ error: 'Failed to connect to the server' }));
 
-    const json = await response.json();
 
     if (json.error) {
       submitButton.disabled = false;


### PR DESCRIPTION
Times out the login endpoint after 5 seconds of no response. This also handles responses where the json can't be parsed.

It handles the following scenarios in my testing.
- Server takes long to respond
- Empty body
- Response can't be given (i blocked the url)